### PR TITLE
Getting basename for caller_shell_ps

### DIFF
--- a/backend.sh
+++ b/backend.sh
@@ -16,6 +16,7 @@ else
     CALLER_SHELL_PS=`ps -ocomm= -p $PPID` #Grab the parent process shell.
     CALLER_SHELL_PS=${CALLER_SHELL_PS##-} #Remove '-' if prefixed.
 fi
+CALLER_SHELL_PS=${CALLER_SHELL_PS##*/} #Grab the basename in case of full path (e.g. /bin/bash)
 
 #Detect whether the frontend was called in bash or tcsh (note: backend is always called using bash)
 if [[ ${CALLER_SHELL_PS} == *bash* ]]; then


### PR DESCRIPTION
Hey Aaron, 

I noticed a problem when using vscode+apple+bash. In apple+vscode, for some reason, the CALLER_SHELL_PS returns /bin/bash (complete path). This patch takes the basename only.

This should help. I am not sure if this is the best way. I can propose other solutions if this does not work in other systems. You know best. 

